### PR TITLE
fix: resolve missing tags for serverless DLT pipelines in usage data model

### DIFF
--- a/Observability Dashboards and DBA Resources/Account Usage Dashboard/Account Usage Dashboard v3 - Data Model.sql
+++ b/Observability Dashboards and DBA Resources/Account Usage Dashboard/Account Usage Dashboard v3 - Data Model.sql
@@ -6,11 +6,48 @@ SCHEDULE EVERY 1 HOUR
 AS 
 SELECT * FROM system.access.workspaces_latest;
 
-CREATE MATERIALIZED VIEW IF NOT EXISTS main.account_usage_dashboard.usage
+CREATE OR REPLACE MATERIALIZED VIEW main.account_usage_dashboard.usage
 SCHEDULE EVERY 1 HOUR
 CLUSTER BY (usage_date, workspace_id, sku_name)
-AS 
-(SELECT * FROM system.billing.usage);
+AS
+-- For serverless DLT, custom_tags is always empty because there is no user-managed
+-- cluster to propagate tags through. We fall back to pipeline-level tags from
+-- system.lakeflow.pipelines, joined via usage_metadata.dlt_pipeline_id.
+WITH pipeline_tags AS (
+  SELECT pipeline_id, tags
+  FROM (
+    SELECT pipeline_id, tags,
+           ROW_NUMBER() OVER (PARTITION BY pipeline_id ORDER BY change_time DESC) AS rn
+    FROM system.lakeflow.pipelines
+    WHERE delete_time IS NULL
+  )
+  WHERE rn = 1
+)
+SELECT
+  u.account_id,
+  u.workspace_id,
+  u.record_id,
+  u.sku_name,
+  u.cloud,
+  u.usage_start_time,
+  u.usage_end_time,
+  u.usage_date,
+  CASE
+    WHEN u.custom_tags IS NULL OR size(u.custom_tags) = 0 THEN pt.tags
+    ELSE u.custom_tags
+  END AS custom_tags,
+  u.usage_unit,
+  u.usage_quantity,
+  u.usage_metadata,
+  u.identity_metadata,
+  u.record_type,
+  u.ingestion_date,
+  u.billing_origin_product,
+  u.product_features,
+  u.usage_type
+FROM system.billing.usage u
+LEFT JOIN pipeline_tags pt
+  ON u.usage_metadata.dlt_pipeline_id = pt.pipeline_id;
 
 CREATE MATERIALIZED VIEW IF NOT EXISTS main.account_usage_dashboard.list_prices
 CLUSTER BY (sku_name)


### PR DESCRIPTION
## Problem

Serverless DLT pipelines show as `<NOT TAGGED>` in the Account Usage Dashboard even when the pipelines have tags configured. This causes tag-based cost attribution to be severely understated for DLT spend.

**Root cause:** For serverless DLT, `system.billing.usage.custom_tags` is always empty (`{}`). Classic DLT propagates tags via the user-managed cluster, but serverless DLT runs on Databricks-managed compute with no cluster-level tag propagation path. The tags exist in `system.lakeflow.pipelines.tags` but were never bridged into billing records.

Observed impact in a production workspace (last 30 days):

| Compute | Rows | Tagged | % Tagged |
|---|---|---|---|
| Classic DLT | 4,430 | 4,393 | 99.2% |
| Serverless DLT | 78,130 | 0 | **0.0%** |

## Fix

Updated the `main.account_usage_dashboard.usage` materialized view to join `system.lakeflow.pipelines` on `usage_metadata.dlt_pipeline_id` and fall back to pipeline-level tags when `custom_tags` is null or empty.

- Only the latest non-deleted record per pipeline is used (ROW_NUMBER on `change_time`) to avoid fanout on the SCD-style pipelines system table
- No impact on non-DLT rows — `dlt_pipeline_id` is NULL for those, so the LEFT JOIN produces no match and existing `custom_tags` are preserved
- No dashboard JSON changes required

## Before / After

![DE6ABD90-49A6-4231-9395-FDD221F4CD05_1_201_a](https://github.com/user-attachments/assets/d6d7270b-1f6e-4f1c-9a73-8b38c43a8b50)

![05B682C7-7E51-4198-B563-475667D0E46C_1_201_a](https://github.com/user-attachments/assets/9f759228-30b6-4204-8bbe-c5c4257aa86f)


## Test plan

- [x] Confirmed `custom_tags` is always `{}` for serverless DLT rows in `system.billing.usage`
- [x] Confirmed `usage_metadata.dlt_pipeline_id` is populated on all serverless DLT rows
- [x] Confirmed tags exist in `system.lakeflow.pipelines.tags` for affected pipelines
- [x] Deployed updated MV to production and verified tag attribution is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)